### PR TITLE
Changing the master-slave words

### DIFF
--- a/bigip_device_facts.py
+++ b/bigip_device_facts.py
@@ -6523,7 +6523,7 @@ class BaseManager(object):
         #  }
         #
         # This list is provided to the specific fact manager by the
-        # master ModuleManager of this module.
+        # main ModuleManager of this module.
         self.provisioned_modules = []
 
     def exec_module(self):

--- a/test_backend.py
+++ b/test_backend.py
@@ -66,7 +66,7 @@ class TestContainerBroker(unittest.TestCase):
             curs = conn.cursor()
             curs.execute('SELECT 1')
             self.assertEqual(curs.fetchall()[0][0], 1)
-            curs.execute("SELECT name FROM sqlite_master WHERE type='table';")
+            curs.execute("SELECT name FROM sqlite_main WHERE type='table';")
             self.assertEqual(self.expected_db_tables,
                              {row[0] for row in curs.fetchall()})
         # check the update trigger

--- a/test_compute.py
+++ b/test_compute.py
@@ -760,7 +760,7 @@ class ComputeVolumeTestCase(BaseTestCase):
         mock_get_counter.assert_called_once_with([])
         mock_last.assert_called_once_with()
         mock_get_host.assert_called_once_with(ctxt, 'fake-mini',
-                                              use_slave=True)
+                                              use_subordinate=True)
 
     @mock.patch.object(objects.InstanceList, 'get_by_host')
     @mock.patch.object(objects.BlockDeviceMappingList,
@@ -779,10 +779,10 @@ class ComputeVolumeTestCase(BaseTestCase):
         got_host_bdms = self.compute._get_host_volume_bdms('fake-context')
         mock_get_by_host.assert_called_once_with('fake-context',
                                                  self.compute.host,
-                                                 use_slave=False)
+                                                 use_subordinate=False)
         mock_get_by_inst.assert_called_once_with('fake-context',
                                                  uuids.volume_instance,
-                                                 use_slave=False)
+                                                 use_subordinate=False)
         self.assertEqual(expected_host_bdms, got_host_bdms)
 
     @mock.patch.object(utils, 'last_completed_audit_period')
@@ -808,7 +808,7 @@ class ComputeVolumeTestCase(BaseTestCase):
         self.flags(volume_usage_poll_interval=10)
         self.compute._poll_volume_usage(ctxt)
 
-        mock_get_bdms.assert_called_once_with(ctxt, use_slave=True)
+        mock_get_bdms.assert_called_once_with(ctxt, use_subordinate=True)
 
     @mock.patch.object(compute_utils, 'notify_about_volume_usage')
     @mock.patch.object(compute_manager.ComputeManager, '_get_host_volume_bdms')
@@ -828,7 +828,7 @@ class ComputeVolumeTestCase(BaseTestCase):
         self.flags(volume_usage_poll_interval=10)
         self.compute._poll_volume_usage(self.context)
 
-        mock_get_bdms.assert_called_once_with(self.context, use_slave=True)
+        mock_get_bdms.assert_called_once_with(self.context, use_subordinate=True)
         mock_notify.assert_called_once_with(
             self.context, test.MatchType(objects.VolumeUsage),
             self.compute.host)
@@ -947,7 +947,7 @@ class ComputeVolumeTestCase(BaseTestCase):
         mock_get.assert_called_once_with(self.context, uuids.volume_id,
                                          instance.uuid)
         mock_stats.assert_called_once_with(instance, 'vdb')
-        mock_get_bdms.assert_called_once_with(self.context, use_slave=True)
+        mock_get_bdms.assert_called_once_with(self.context, use_subordinate=True)
         mock_get_all(self.context, host_volume_bdms)
         mock_exists.assert_called_once_with(mock.ANY)
 
@@ -7029,8 +7029,8 @@ class ComputeTestCase(BaseTestCase,
         mock_cleanup.assert_called_once_with(ctxt, inst2, bdms,
                                              detach=False)
         mock_get_uuid.assert_has_calls([
-            mock.call(ctxt, inst1.uuid, use_slave=True),
-            mock.call(ctxt, inst2.uuid, use_slave=True)])
+            mock.call(ctxt, inst1.uuid, use_subordinate=True),
+            mock.call(ctxt, inst2.uuid, use_subordinate=True)])
         mock_get_inst.assert_called_once_with(ctxt,
                                               {'deleted': True,
                                                'soft_deleted': False})
@@ -7134,13 +7134,13 @@ class ComputeTestCase(BaseTestCase,
                 'get_nw_info': 0, 'expected_instance': None}
 
         def fake_instance_get_all_by_host(context, host,
-                                          columns_to_join, use_slave=False):
+                                          columns_to_join, use_subordinate=False):
             call_info['get_all_by_host'] += 1
             self.assertEqual([], columns_to_join)
             return instances[:]
 
         def fake_instance_get_by_uuid(context, instance_uuid,
-                                      columns_to_join, use_slave=False):
+                                      columns_to_join, use_subordinate=False):
             if instance_uuid not in instance_map:
                 raise exception.InstanceNotFound(instance_id=instance_uuid)
             call_info['get_by_uuid'] += 1
@@ -7151,7 +7151,7 @@ class ComputeTestCase(BaseTestCase,
 
         # NOTE(comstud): Override the stub in setUp()
         def fake_get_instance_nw_info(cls, context, instance,
-                                      use_slave=False):
+                                      use_subordinate=False):
             # Note that this exception gets caught in compute/manager
             # and is ignored.  However, the below increment of
             # 'get_nw_info' won't happen, and you'll get an assert
@@ -7254,7 +7254,7 @@ class ComputeTestCase(BaseTestCase,
 
         def fake_instance_get_all_by_filters(context, filters,
                                              expected_attrs=None,
-                                             use_slave=False):
+                                             use_subordinate=False):
             self.assertEqual(["system_metadata"], expected_attrs)
             return instances
 
@@ -7304,7 +7304,7 @@ class ComputeTestCase(BaseTestCase,
                        task_states.REBOOTING, task_states.REBOOT_STARTED,
                        task_states.REBOOT_PENDING]}
         get.assert_called_once_with(ctxt, filters,
-                                    expected_attrs=[], use_slave=True)
+                                    expected_attrs=[], use_subordinate=True)
 
     def test_poll_unconfirmed_resizes(self):
         instances = [
@@ -7356,7 +7356,7 @@ class ComputeTestCase(BaseTestCase,
             migrations.append(fake_mig)
 
         def fake_instance_get_by_uuid(context, instance_uuid,
-                columns_to_join=None, use_slave=False):
+                columns_to_join=None, use_subordinate=False):
             self.assertIn('metadata', columns_to_join)
             self.assertIn('system_metadata', columns_to_join)
             # raise InstanceNotFound exception for non-existing instance
@@ -7368,7 +7368,7 @@ class ComputeTestCase(BaseTestCase,
                     return instance
 
         def fake_migration_get_unconfirmed_by_dest_compute(context,
-                resize_confirm_window, dest_compute, use_slave=False):
+                resize_confirm_window, dest_compute, use_subordinate=False):
             self.assertEqual(dest_compute, CONF.host)
             return migrations
 
@@ -7878,7 +7878,7 @@ class ComputeTestCase(BaseTestCase,
 
         mock_get_filter.assert_called_once_with(ctxt, mock.ANY,
                 expected_attrs=instance_obj.INSTANCE_DEFAULT_FIELDS,
-                use_slave=True)
+                use_subordinate=True)
         mock_delete_old.assert_has_calls([mock.call(instance1, 3600),
                                           mock.call(instance2, 3600)])
         mock_get_uuid.assert_has_calls([mock.call(ctxt, instance1.uuid),
@@ -7908,9 +7908,9 @@ class ComputeTestCase(BaseTestCase,
         mock_get.assert_has_calls([mock.call(mock.ANY), mock.call(mock.ANY),
                                    mock.call(mock.ANY)])
         mock_sync.assert_has_calls([
-            mock.call(ctxt, mock.ANY, power_state.NOSTATE, use_slave=True),
-            mock.call(ctxt, mock.ANY, power_state.RUNNING, use_slave=True),
-            mock.call(ctxt, mock.ANY, power_state.SHUTDOWN, use_slave=True)])
+            mock.call(ctxt, mock.ANY, power_state.NOSTATE, use_subordinate=True),
+            mock.call(ctxt, mock.ANY, power_state.RUNNING, use_subordinate=True),
+            mock.call(ctxt, mock.ANY, power_state.SHUTDOWN, use_subordinate=True)])
 
     @mock.patch.object(compute_manager.ComputeManager, '_get_power_state')
     @mock.patch.object(compute_manager.ComputeManager,
@@ -12415,7 +12415,7 @@ class ComputeAggrTestCase(BaseTestCase):
                        fake_driver_add_to_aggregate)
 
         self.compute.add_aggregate_host(self.context, host="host",
-            aggregate=self.aggr, slave_info=None)
+            aggregate=self.aggr, subordinate_info=None)
         self.assertTrue(fake_driver_add_to_aggregate.called)
 
     def test_remove_aggregate_host(self):
@@ -12428,35 +12428,35 @@ class ComputeAggrTestCase(BaseTestCase):
                        fake_driver_remove_from_aggregate)
 
         self.compute.remove_aggregate_host(self.context,
-            aggregate=self.aggr, host="host", slave_info=None)
+            aggregate=self.aggr, host="host", subordinate_info=None)
         self.assertTrue(fake_driver_remove_from_aggregate.called)
 
-    def test_add_aggregate_host_passes_slave_info_to_driver(self):
+    def test_add_aggregate_host_passes_subordinate_info_to_driver(self):
         def driver_add_to_aggregate(cls, context, aggregate, host, **kwargs):
             self.assertEqual(self.context, context)
             self.assertEqual(aggregate.id, self.aggr.id)
             self.assertEqual(host, "the_host")
-            self.assertEqual("SLAVE_INFO", kwargs.get("slave_info"))
+            self.assertEqual("SLAVE_INFO", kwargs.get("subordinate_info"))
 
         self.stub_out("nova.virt.fake.FakeDriver.add_to_aggregate",
                        driver_add_to_aggregate)
 
         self.compute.add_aggregate_host(self.context, host="the_host",
-            slave_info="SLAVE_INFO", aggregate=self.aggr)
+            subordinate_info="SLAVE_INFO", aggregate=self.aggr)
 
-    def test_remove_from_aggregate_passes_slave_info_to_driver(self):
+    def test_remove_from_aggregate_passes_subordinate_info_to_driver(self):
         def driver_remove_from_aggregate(cls, context, aggregate, host,
                                          **kwargs):
             self.assertEqual(self.context, context)
             self.assertEqual(aggregate.id, self.aggr.id)
             self.assertEqual(host, "the_host")
-            self.assertEqual("SLAVE_INFO", kwargs.get("slave_info"))
+            self.assertEqual("SLAVE_INFO", kwargs.get("subordinate_info"))
 
         self.stub_out("nova.virt.fake.FakeDriver.remove_from_aggregate",
                        driver_remove_from_aggregate)
 
         self.compute.remove_aggregate_host(self.context,
-            aggregate=self.aggr, host="the_host", slave_info="SLAVE_INFO")
+            aggregate=self.aggr, host="the_host", subordinate_info="SLAVE_INFO")
 
 
 class DisabledInstanceTypesTestCase(BaseTestCase):

--- a/test_compute_1.py
+++ b/test_compute_1.py
@@ -760,7 +760,7 @@ class ComputeVolumeTestCase(BaseTestCase):
         mock_get_counter.assert_called_once_with([])
         mock_last.assert_called_once_with()
         mock_get_host.assert_called_once_with(ctxt, 'fake-mini',
-                                              use_slave=True)
+                                              use_subordinate=True)
 
     @mock.patch.object(objects.InstanceList, 'get_by_host')
     @mock.patch.object(objects.BlockDeviceMappingList,
@@ -779,10 +779,10 @@ class ComputeVolumeTestCase(BaseTestCase):
         got_host_bdms = self.compute._get_host_volume_bdms('fake-context')
         mock_get_by_host.assert_called_once_with('fake-context',
                                                  self.compute.host,
-                                                 use_slave=False)
+                                                 use_subordinate=False)
         mock_get_by_inst.assert_called_once_with('fake-context',
                                                  uuids.volume_instance,
-                                                 use_slave=False)
+                                                 use_subordinate=False)
         self.assertEqual(expected_host_bdms, got_host_bdms)
 
     @mock.patch.object(utils, 'last_completed_audit_period')
@@ -808,7 +808,7 @@ class ComputeVolumeTestCase(BaseTestCase):
         self.flags(volume_usage_poll_interval=10)
         self.compute._poll_volume_usage(ctxt)
 
-        mock_get_bdms.assert_called_once_with(ctxt, use_slave=True)
+        mock_get_bdms.assert_called_once_with(ctxt, use_subordinate=True)
 
     @mock.patch.object(compute_utils, 'notify_about_volume_usage')
     @mock.patch.object(compute_manager.ComputeManager, '_get_host_volume_bdms')
@@ -828,7 +828,7 @@ class ComputeVolumeTestCase(BaseTestCase):
         self.flags(volume_usage_poll_interval=10)
         self.compute._poll_volume_usage(self.context)
 
-        mock_get_bdms.assert_called_once_with(self.context, use_slave=True)
+        mock_get_bdms.assert_called_once_with(self.context, use_subordinate=True)
         mock_notify.assert_called_once_with(
             self.context, test.MatchType(objects.VolumeUsage),
             self.compute.host)
@@ -947,7 +947,7 @@ class ComputeVolumeTestCase(BaseTestCase):
         mock_get.assert_called_once_with(self.context, uuids.volume_id,
                                          instance.uuid)
         mock_stats.assert_called_once_with(instance, 'vdb')
-        mock_get_bdms.assert_called_once_with(self.context, use_slave=True)
+        mock_get_bdms.assert_called_once_with(self.context, use_subordinate=True)
         mock_get_all(self.context, host_volume_bdms)
         mock_exists.assert_called_once_with(mock.ANY)
 
@@ -7029,8 +7029,8 @@ class ComputeTestCase(BaseTestCase,
         mock_cleanup.assert_called_once_with(ctxt, inst2, bdms,
                                              detach=False)
         mock_get_uuid.assert_has_calls([
-            mock.call(ctxt, inst1.uuid, use_slave=True),
-            mock.call(ctxt, inst2.uuid, use_slave=True)])
+            mock.call(ctxt, inst1.uuid, use_subordinate=True),
+            mock.call(ctxt, inst2.uuid, use_subordinate=True)])
         mock_get_inst.assert_called_once_with(ctxt,
                                               {'deleted': True,
                                                'soft_deleted': False})
@@ -7134,13 +7134,13 @@ class ComputeTestCase(BaseTestCase,
                 'get_nw_info': 0, 'expected_instance': None}
 
         def fake_instance_get_all_by_host(context, host,
-                                          columns_to_join, use_slave=False):
+                                          columns_to_join, use_subordinate=False):
             call_info['get_all_by_host'] += 1
             self.assertEqual([], columns_to_join)
             return instances[:]
 
         def fake_instance_get_by_uuid(context, instance_uuid,
-                                      columns_to_join, use_slave=False):
+                                      columns_to_join, use_subordinate=False):
             if instance_uuid not in instance_map:
                 raise exception.InstanceNotFound(instance_id=instance_uuid)
             call_info['get_by_uuid'] += 1
@@ -7151,7 +7151,7 @@ class ComputeTestCase(BaseTestCase,
 
         # NOTE(comstud): Override the stub in setUp()
         def fake_get_instance_nw_info(cls, context, instance,
-                                      use_slave=False):
+                                      use_subordinate=False):
             # Note that this exception gets caught in compute/manager
             # and is ignored.  However, the below increment of
             # 'get_nw_info' won't happen, and you'll get an assert
@@ -7254,7 +7254,7 @@ class ComputeTestCase(BaseTestCase,
 
         def fake_instance_get_all_by_filters(context, filters,
                                              expected_attrs=None,
-                                             use_slave=False):
+                                             use_subordinate=False):
             self.assertEqual(["system_metadata"], expected_attrs)
             return instances
 
@@ -7304,7 +7304,7 @@ class ComputeTestCase(BaseTestCase,
                        task_states.REBOOTING, task_states.REBOOT_STARTED,
                        task_states.REBOOT_PENDING]}
         get.assert_called_once_with(ctxt, filters,
-                                    expected_attrs=[], use_slave=True)
+                                    expected_attrs=[], use_subordinate=True)
 
     def test_poll_unconfirmed_resizes(self):
         instances = [
@@ -7356,7 +7356,7 @@ class ComputeTestCase(BaseTestCase,
             migrations.append(fake_mig)
 
         def fake_instance_get_by_uuid(context, instance_uuid,
-                columns_to_join=None, use_slave=False):
+                columns_to_join=None, use_subordinate=False):
             self.assertIn('metadata', columns_to_join)
             self.assertIn('system_metadata', columns_to_join)
             # raise InstanceNotFound exception for non-existing instance
@@ -7368,7 +7368,7 @@ class ComputeTestCase(BaseTestCase,
                     return instance
 
         def fake_migration_get_unconfirmed_by_dest_compute(context,
-                resize_confirm_window, dest_compute, use_slave=False):
+                resize_confirm_window, dest_compute, use_subordinate=False):
             self.assertEqual(dest_compute, CONF.host)
             return migrations
 
@@ -7878,7 +7878,7 @@ class ComputeTestCase(BaseTestCase,
 
         mock_get_filter.assert_called_once_with(ctxt, mock.ANY,
                 expected_attrs=instance_obj.INSTANCE_DEFAULT_FIELDS,
-                use_slave=True)
+                use_subordinate=True)
         mock_delete_old.assert_has_calls([mock.call(instance1, 3600),
                                           mock.call(instance2, 3600)])
         mock_get_uuid.assert_has_calls([mock.call(ctxt, instance1.uuid),
@@ -7908,9 +7908,9 @@ class ComputeTestCase(BaseTestCase,
         mock_get.assert_has_calls([mock.call(mock.ANY), mock.call(mock.ANY),
                                    mock.call(mock.ANY)])
         mock_sync.assert_has_calls([
-            mock.call(ctxt, mock.ANY, power_state.NOSTATE, use_slave=True),
-            mock.call(ctxt, mock.ANY, power_state.RUNNING, use_slave=True),
-            mock.call(ctxt, mock.ANY, power_state.SHUTDOWN, use_slave=True)])
+            mock.call(ctxt, mock.ANY, power_state.NOSTATE, use_subordinate=True),
+            mock.call(ctxt, mock.ANY, power_state.RUNNING, use_subordinate=True),
+            mock.call(ctxt, mock.ANY, power_state.SHUTDOWN, use_subordinate=True)])
 
     @mock.patch.object(compute_manager.ComputeManager, '_get_power_state')
     @mock.patch.object(compute_manager.ComputeManager,
@@ -12415,7 +12415,7 @@ class ComputeAggrTestCase(BaseTestCase):
                        fake_driver_add_to_aggregate)
 
         self.compute.add_aggregate_host(self.context, host="host",
-            aggregate=self.aggr, slave_info=None)
+            aggregate=self.aggr, subordinate_info=None)
         self.assertTrue(fake_driver_add_to_aggregate.called)
 
     def test_remove_aggregate_host(self):
@@ -12428,35 +12428,35 @@ class ComputeAggrTestCase(BaseTestCase):
                        fake_driver_remove_from_aggregate)
 
         self.compute.remove_aggregate_host(self.context,
-            aggregate=self.aggr, host="host", slave_info=None)
+            aggregate=self.aggr, host="host", subordinate_info=None)
         self.assertTrue(fake_driver_remove_from_aggregate.called)
 
-    def test_add_aggregate_host_passes_slave_info_to_driver(self):
+    def test_add_aggregate_host_passes_subordinate_info_to_driver(self):
         def driver_add_to_aggregate(cls, context, aggregate, host, **kwargs):
             self.assertEqual(self.context, context)
             self.assertEqual(aggregate.id, self.aggr.id)
             self.assertEqual(host, "the_host")
-            self.assertEqual("SLAVE_INFO", kwargs.get("slave_info"))
+            self.assertEqual("SLAVE_INFO", kwargs.get("subordinate_info"))
 
         self.stub_out("nova.virt.fake.FakeDriver.add_to_aggregate",
                        driver_add_to_aggregate)
 
         self.compute.add_aggregate_host(self.context, host="the_host",
-            slave_info="SLAVE_INFO", aggregate=self.aggr)
+            subordinate_info="SLAVE_INFO", aggregate=self.aggr)
 
-    def test_remove_from_aggregate_passes_slave_info_to_driver(self):
+    def test_remove_from_aggregate_passes_subordinate_info_to_driver(self):
         def driver_remove_from_aggregate(cls, context, aggregate, host,
                                          **kwargs):
             self.assertEqual(self.context, context)
             self.assertEqual(aggregate.id, self.aggr.id)
             self.assertEqual(host, "the_host")
-            self.assertEqual("SLAVE_INFO", kwargs.get("slave_info"))
+            self.assertEqual("SLAVE_INFO", kwargs.get("subordinate_info"))
 
         self.stub_out("nova.virt.fake.FakeDriver.remove_from_aggregate",
                        driver_remove_from_aggregate)
 
         self.compute.remove_aggregate_host(self.context,
-            aggregate=self.aggr, host="the_host", slave_info="SLAVE_INFO")
+            aggregate=self.aggr, host="the_host", subordinate_info="SLAVE_INFO")
 
 
 class DisabledInstanceTypesTestCase(BaseTestCase):

--- a/test_compute_mgr.py
+++ b/test_compute_mgr.py
@@ -350,7 +350,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
         get_db_nodes.return_value = db_nodes
         get_avail_nodes.return_value = avail_nodes
         self.compute.update_available_resource(self.context, startup=True)
-        get_db_nodes.assert_called_once_with(self.context, use_slave=True,
+        get_db_nodes.assert_called_once_with(self.context, use_subordinate=True,
                                              startup=True)
         update_mock.has_calls(
             [mock.call(self.context, node, startup=True)
@@ -410,7 +410,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
         self.assertEqual([], self.compute._get_compute_nodes_in_db(
             self.context, startup=True))
         get_all_by_host.assert_called_once_with(
-            self.context, self.compute.host, use_slave=False)
+            self.context, self.compute.host, use_subordinate=False)
         self.assertTrue(mock_log.warning.called)
         self.assertFalse(mock_log.error.called)
 
@@ -1691,7 +1691,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
                          [x['uuid'] for x in result])
         expected_filters = {'uuid': driver_uuids}
         mock_instance_list.assert_called_with(self.context, expected_filters,
-                                              use_slave=True)
+                                              use_subordinate=True)
 
     @mock.patch('nova.objects.InstanceList.get_by_filters')
     def test_get_instances_on_driver_empty(self, mock_instance_list):
@@ -1746,7 +1746,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
                          [x['uuid'] for x in result])
         expected_filters = {'host': self.compute.host}
         mock_instance_list.assert_called_with(self.context, expected_filters,
-                                              use_slave=True)
+                                              use_subordinate=True)
 
     @mock.patch.object(compute_utils, 'notify_usage_exists')
     @mock.patch.object(objects.TaskLog, 'end_task')
@@ -1786,7 +1786,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
             self.compute._sync_power_states(mock.sentinel.context)
             mock_get.assert_called_with(mock.sentinel.context,
                                         self.compute.host, expected_attrs=[],
-                                        use_slave=True)
+                                        use_subordinate=True)
             mock_spawn.assert_called_once_with(mock.ANY, instance)
 
     @mock.patch('nova.objects.InstanceList.get_by_host', new=mock.Mock())
@@ -1820,7 +1820,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
                                            vm_states.ACTIVE)
         self.compute._sync_instance_power_state(self.context, instance,
                                                 power_state.RUNNING)
-        mock_refresh.assert_called_once_with(use_slave=False)
+        mock_refresh.assert_called_once_with(use_subordinate=False)
 
     @mock.patch.object(objects.Instance, 'refresh')
     @mock.patch.object(objects.Instance, 'save')
@@ -1831,7 +1831,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
         self.compute._sync_instance_power_state(self.context, instance,
                                                 power_state.SHUTDOWN)
         self.assertEqual(instance.power_state, power_state.SHUTDOWN)
-        mock_refresh.assert_called_once_with(use_slave=False)
+        mock_refresh.assert_called_once_with(use_subordinate=False)
         self.assertTrue(mock_save.called)
 
     def _test_sync_to_stop(self, power_state, vm_state, driver_power_state,
@@ -1855,7 +1855,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
                     mock_force.assert_called_once_with(self.context, instance)
                 else:
                     mock_stop.assert_called_once_with(self.context, instance)
-            mock_refresh.assert_called_once_with(use_slave=False)
+            mock_refresh.assert_called_once_with(use_subordinate=False)
             self.assertTrue(mock_save.called)
 
     def test_sync_instance_power_state_to_stop(self):
@@ -1912,7 +1912,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
             mock_sync_power_state.assert_called_once_with(self.context,
                                                           db_instance,
                                                           power_state.NOSTATE,
-                                                          use_slave=True)
+                                                          use_subordinate=True)
 
     @mock.patch.object(virt_driver.ComputeDriver, 'delete_instance_files')
     @mock.patch.object(objects.InstanceList, 'get_by_filters')
@@ -1932,13 +1932,13 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
             def save(self):
                 pass
 
-        def _fake_get(ctx, filter, expected_attrs, use_slave):
+        def _fake_get(ctx, filter, expected_attrs, use_subordinate):
             mock_get.assert_called_once_with(
                 {'read_deleted': 'yes'},
                 {'deleted': True, 'soft_deleted': False, 'host': 'fake-mini',
                  'cleaned': False},
                 expected_attrs=['system_metadata'],
-                use_slave=True)
+                use_subordinate=True)
             return [a, b, c]
 
         a = FakeInstance(uuids.instanceA, 'apple', {'clean_attempts': '100'})
@@ -4549,7 +4549,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
             self.compute._poll_bandwidth_usage(self.context)
             get_by_uuid_mac.assert_called_once_with(self.context,
                     uuids.instance, 'fake-mac',
-                    start_period=0, use_slave=True)
+                    start_period=0, use_subordinate=True)
             # NOTE(sdague): bw_usage_update happens at some time in
             # the future, so what last_refreshed is irrelevant.
             bw_usage_update.assert_called_once_with(self.context,
@@ -4676,7 +4676,7 @@ class ComputeManagerUnitTestCase(test.NoDBTestCase):
         self.compute._sync_scheduler_instance_info(self.context)
         mock_get_by_host.assert_called_once_with(
                 fake_elevated, self.compute.host, expected_attrs=[],
-                use_slave=True)
+                use_subordinate=True)
         mock_sync.assert_called_once_with(fake_elevated, self.compute.host,
                                           exp_uuids)
 

--- a/test_conductor.py
+++ b/test_conductor.py
@@ -2947,7 +2947,7 @@ class ConductorTaskTestCase(_BaseTaskTestCase, test_compute.BaseTestCase):
         get_source_node.assert_called_once_with(
             self.ctxt, instance.host, instance.node)
         get_dest_node.assert_called_once_with(
-            self.ctxt, 'dest-host', use_slave=True)
+            self.ctxt, 'dest-host', use_subordinate=True)
         notify.assert_called_once_with(
             self.ctxt, instance.uuid, 'rebuild_server',
             {'vm_state': instance.vm_state, 'task_state': None}, ex, reqspec)
@@ -2979,7 +2979,7 @@ class ConductorTaskTestCase(_BaseTaskTestCase, test_compute.BaseTestCase):
         get_source_node.assert_called_once_with(
             self.ctxt, instance.host, instance.node)
         get_dest_node.assert_called_once_with(
-            self.ctxt, 'dest-host', use_slave=True)
+            self.ctxt, 'dest-host', use_subordinate=True)
         claim.assert_called_once_with(
             self.ctxt, self.conductor.scheduler_client.reportclient, instance,
             get_source_node.return_value, get_dest_node.return_value)

--- a/test_reconstructor.py
+++ b/test_reconstructor.py
@@ -4687,7 +4687,7 @@ class TestReconstructFragmentArchive(BaseTestObjectReconstructor):
         # function is that it will cause a bunch of warning log from
         # liberasurecode[1].
         # 1: https://github.com/openstack/liberasurecode/blob/
-        #    master/src/erasurecode.c#L870
+        #    main/src/erasurecode.c#L870
         log_prefix = 'Reconstruct frag #%s with frag indexes' % broken_node
         self.assertIn(log_prefix, debug_log_lines[1])
         self.assertFalse(debug_log_lines[2:])

--- a/test_serversV21.py
+++ b/test_serversV21.py
@@ -114,7 +114,7 @@ def fake_start_stop_invalid_state(self, context, instance):
 
 
 def fake_instance_get_by_uuid_not_found(context, uuid,
-                                        columns_to_join, use_slave=False):
+                                        columns_to_join, use_subordinate=False):
     raise exception.InstanceNotFound(instance_id=uuid)
 
 

--- a/test_xenapi.py
+++ b/test_xenapi.py
@@ -3158,7 +3158,7 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
         self.aggr = objects.Aggregate(context=self.context, id=1,
                                       **values)
         self.fake_metadata = {pool_states.POOL_FLAG: 'XenAPI',
-                              'master_compute': 'host',
+                              'main_compute': 'host',
                               'availability_zone': 'fake_zone',
                               pool_states.KEY: pool_states.ACTIVE,
                               'host': xenapi_fake.get_record('host',
@@ -3168,15 +3168,15 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
     @mock.patch('nova.virt.xenapi.pool.ResourcePool.add_to_aggregate')
     def test_pool_add_to_aggregate_called_by_driver(
             self, mock_add_to_aggregate):
-        def pool_add_to_aggregate(context, aggregate, host, slave_info=None):
+        def pool_add_to_aggregate(context, aggregate, host, subordinate_info=None):
             self.assertEqual("CONTEXT", context)
             self.assertEqual("AGGREGATE", aggregate)
             self.assertEqual("HOST", host)
-            self.assertEqual("SLAVEINFO", slave_info)
+            self.assertEqual("SLAVEINFO", subordinate_info)
         mock_add_to_aggregate.side_effect = pool_add_to_aggregate
 
         self.conn.add_to_aggregate("CONTEXT", "AGGREGATE", "HOST",
-                                   slave_info="SLAVEINFO")
+                                   subordinate_info="SLAVEINFO")
 
         self.assertTrue(mock_add_to_aggregate.called)
 
@@ -3184,14 +3184,14 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
     def test_pool_remove_from_aggregate_called_by_driver(
             self, mock_remove_from_aggregate):
         def pool_remove_from_aggregate(context, aggregate, host,
-                                       slave_info=None):
+                                       subordinate_info=None):
             self.assertEqual("CONTEXT", context)
             self.assertEqual("AGGREGATE", aggregate)
             self.assertEqual("HOST", host)
-            self.assertEqual("SLAVEINFO", slave_info)
+            self.assertEqual("SLAVEINFO", subordinate_info)
         mock_remove_from_aggregate.side_effect = pool_remove_from_aggregate
         self.conn.remove_from_aggregate("CONTEXT", "AGGREGATE", "HOST",
-                                        slave_info="SLAVEINFO")
+                                        subordinate_info="SLAVEINFO")
 
         self.assertTrue(mock_remove_from_aggregate.called)
 
@@ -3205,9 +3205,9 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
         self.assertThat(self.fake_metadata,
                         matchers.DictMatches(result.metadata))
 
-    @mock.patch('nova.virt.xenapi.pool.ResourcePool._join_slave')
-    def test_join_slave(self, mock_join_slave):
-        # Ensure join_slave gets called when the request gets to master.
+    @mock.patch('nova.virt.xenapi.pool.ResourcePool._join_subordinate')
+    def test_join_subordinate(self, mock_join_subordinate):
+        # Ensure join_subordinate gets called when the request gets to main.
         aggregate = self._aggregate_setup(hosts=['host', 'host2'],
                                           metadata=self.fake_metadata)
         self.conn._pool.add_to_aggregate(self.context, aggregate, "host2",
@@ -3216,7 +3216,7 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                                          user='fake_user',
                                          passwd='fake_pass',
                                          xenhost_uuid='fake_uuid'))
-        self.assertTrue(mock_join_slave.called)
+        self.assertTrue(mock_join_subordinate.called)
 
     @mock.patch.object(xenapi_fake.SessionBase, 'pool_set_name_label')
     def test_add_to_aggregate_first_host(self, mock_pool_set_name_label):
@@ -3248,17 +3248,17 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                           self.conn._pool.remove_from_aggregate,
                           self.context, result, "test_host")
 
-    @mock.patch('nova.virt.xenapi.pool.ResourcePool._eject_slave')
-    def test_remove_slave(self, mock_eject_slave):
-        # Ensure eject slave gets called.
+    @mock.patch('nova.virt.xenapi.pool.ResourcePool._eject_subordinate')
+    def test_remove_subordinate(self, mock_eject_subordinate):
+        # Ensure eject subordinate gets called.
         self.fake_metadata['host2'] = 'fake_host2_uuid'
         aggregate = self._aggregate_setup(hosts=['host', 'host2'],
                 metadata=self.fake_metadata, aggr_state=pool_states.ACTIVE)
         self.conn._pool.remove_from_aggregate(self.context, aggregate, "host2")
-        self.assertTrue(mock_eject_slave.called)
+        self.assertTrue(mock_eject_subordinate.called)
 
     @mock.patch('nova.virt.xenapi.pool.ResourcePool._clear_pool')
-    def test_remove_master_solo(self, mock_clear_pool):
+    def test_remove_main_solo(self, mock_clear_pool):
         # Ensure metadata are cleared after removal.
         aggregate = self._aggregate_setup(metadata=self.fake_metadata)
         self.conn._pool.remove_from_aggregate(self.context, aggregate, "host")
@@ -3269,8 +3269,8 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                 pool_states.KEY: pool_states.ACTIVE},
                 matchers.DictMatches(result.metadata))
 
-    def test_remote_master_non_empty_pool(self):
-        # Ensure AggregateError is raised if removing the master.
+    def test_remote_main_non_empty_pool(self):
+        # Ensure AggregateError is raised if removing the main.
         aggregate = self._aggregate_setup(hosts=['host', 'host2'],
                                           metadata=self.fake_metadata)
 
@@ -3388,7 +3388,7 @@ class XenAPIAggregateTestCase(stubs.XenAPITestBase):
                           self.compute.add_aggregate_host,
                           self.context, host="fake_host",
                           aggregate=self.aggr,
-                          slave_info=None)
+                          subordinate_info=None)
         self.assertEqual(self.aggr.metadata[pool_states.KEY],
                 pool_states.ERROR)
         self.assertEqual(self.aggr.hosts, ['fake_host'])
@@ -3399,16 +3399,16 @@ class MockComputeAPI(object):
         self._mock_calls = []
 
     def add_aggregate_host(self, ctxt, aggregate,
-                                     host_param, host, slave_info):
+                                     host_param, host, subordinate_info):
         self._mock_calls.append((
             self.add_aggregate_host, ctxt, aggregate,
-            host_param, host, slave_info))
+            host_param, host, subordinate_info))
 
     def remove_aggregate_host(self, ctxt, host, aggregate_id, host_param,
-                              slave_info):
+                              subordinate_info):
         self._mock_calls.append((
             self.remove_aggregate_host, ctxt, host, aggregate_id,
-            host_param, slave_info))
+            host_param, subordinate_info))
 
 
 class StubDependencies(object):
@@ -3423,10 +3423,10 @@ class StubDependencies(object):
     def _get_metadata(self, *_ignore):
         return {
             pool_states.KEY: {},
-            'master_compute': 'master'
+            'main_compute': 'main'
         }
 
-    def _create_slave_info(self, *ignore):
+    def _create_subordinate_info(self, *ignore):
         return "SLAVE_INFO"
 
 
@@ -3440,33 +3440,33 @@ class HypervisorPoolTestCase(test.NoDBTestCase):
         'id': 98,
         'hosts': [],
         'metadata': {
-            'master_compute': 'master',
+            'main_compute': 'main',
             pool_states.POOL_FLAG: '',
             pool_states.KEY: ''
             }
         }
     fake_aggregate = objects.Aggregate(**fake_aggregate)
 
-    def test_slave_asks_master_to_add_slave_to_pool(self):
-        slave = ResourcePoolWithStubs()
+    def test_subordinate_asks_main_to_add_subordinate_to_pool(self):
+        subordinate = ResourcePoolWithStubs()
 
-        slave.add_to_aggregate("CONTEXT", self.fake_aggregate, "slave")
-
-        self.assertIn(
-            (slave.compute_rpcapi.add_aggregate_host,
-            "CONTEXT", "slave", self.fake_aggregate,
-            "master", "SLAVE_INFO"),
-            slave.compute_rpcapi._mock_calls)
-
-    def test_slave_asks_master_to_remove_slave_from_pool(self):
-        slave = ResourcePoolWithStubs()
-
-        slave.remove_from_aggregate("CONTEXT", self.fake_aggregate, "slave")
+        subordinate.add_to_aggregate("CONTEXT", self.fake_aggregate, "subordinate")
 
         self.assertIn(
-            (slave.compute_rpcapi.remove_aggregate_host,
-             "CONTEXT", "slave", 98, "master", "SLAVE_INFO"),
-            slave.compute_rpcapi._mock_calls)
+            (subordinate.compute_rpcapi.add_aggregate_host,
+            "CONTEXT", "subordinate", self.fake_aggregate,
+            "main", "SLAVE_INFO"),
+            subordinate.compute_rpcapi._mock_calls)
+
+    def test_subordinate_asks_main_to_remove_subordinate_from_pool(self):
+        subordinate = ResourcePoolWithStubs()
+
+        subordinate.remove_from_aggregate("CONTEXT", self.fake_aggregate, "subordinate")
+
+        self.assertIn(
+            (subordinate.compute_rpcapi.remove_aggregate_host,
+             "CONTEXT", "subordinate", 98, "main", "SLAVE_INFO"),
+            subordinate.compute_rpcapi._mock_calls)
 
 
 class SwapXapiHostTestCase(test.NoDBTestCase):


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.